### PR TITLE
Fix unsafe isWebP check

### DIFF
--- a/WebPKit/Decoding/Utilities/Data+WebPDecoding.swift
+++ b/WebPKit/Decoding/Utilities/Data+WebPDecoding.swift
@@ -29,6 +29,9 @@ extension Data {
     /// Checks the contents of the data to see if the
     /// header matches that of the WebP file format.
     public var isWebP: Bool {
+        guard self.count >= 12 else {
+            return false
+        }
         return withUnsafeBytes { bytes in
             // The first 4 bytes are the ASCII letters "RIFF"
             // Skipping 4 bytes for the file size, the next 4 bytes after

--- a/WebPKitTests/Decoding/WebPDecodingDataTests.swift
+++ b/WebPKitTests/Decoding/WebPDecodingDataTests.swift
@@ -20,4 +20,10 @@ class WebPDecodingDataTests: WebPDecodingTests {
         let data = "InvalidData".data(using: .ascii)!
         XCTAssertFalse(data.isWebP)
     }
+
+    // Test an incorrect data stream which is shorter than the WebP magic
+    func testTooShortData() {
+        let data = "Tom".data(using: .ascii)!
+        XCTAssertFalse(data.isWebP)
+    }
 }


### PR DESCRIPTION
Potential buffer overflow by reading bytes without checking for the buffer length first.

This would cause otherwise this runtime exception:
```
#0	0x00007fff6dfb1380 in _swift_runtime_on_report ()
#1	0x00007fff6e02b243 in _swift_stdlib_reportFatalErrorInFile ()
#2	0x00007fff6dcf21dd in closure #1 in closure #1 in closure #1 in _assertionFailure(_:_:file:line:flags:) ()
#3	0x00007fff6dcf1cf7 in closure #1 in closure #1 in _assertionFailure(_:_:file:line:flags:) ()
#4	0x00007fff6dcf19c3 in closure #1 in _assertionFailure(_:_:file:line:flags:) ()
#5	0x00007fff6dcf15d5 in _assertionFailure(_:_:file:line:flags:) ()
#6	0x00007fff6dcf18b0 in _fatalErrorMessage(_:_:file:line:flags:) ()
#7	0x00007fff6defa9ab in UnsafeMutableRawBufferPointer.subscript.getter ()
#8	0x00007fff6defa921 in UnsafeRawBufferPointer.subscript.getter ()
#9	0x0000000111b610a3 in closure #1 in Data.isWebP.getter at /Users/marius/Development/WebPKit/WebPKit/Decoding/Utilities/Data+WebPDecoding.swift:39
#10	0x0000000111b61393 in thunk for @callee_guaranteed (@unowned UnsafeRawBufferPointer) -> (@unowned Bool, @error @owned Error) ()
#11	0x0000000111b613f4 in partial apply for thunk for @callee_guaranteed (@unowned UnsafeRawBufferPointer) -> (@unowned Bool, @error @owned Error) ()
#12	0x00007fff6e14ec35 in Data.withUnsafeBytes<A>(_:) ()
#13	0x0000000111b60fdb in Data.isWebP.getter at /Users/marius/Development/WebPKit/WebPKit/Decoding/Utilities/Data+WebPDecoding.swift:35
```